### PR TITLE
Add lxml to install_requires (fixes #1)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setuptools.setup(
         'emcee',
         'numdifftools',
         'lmfit',
-        'transitleastsquares'
+        'transitleastsquares',
+        'lxml'
      ]
 )


### PR DESCRIPTION
Added lxml to install_requires list in `setup.py`. This line

    from splash.download import cambridge_download_product

now runs fine.